### PR TITLE
Add deploy-staging workflow

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -6,7 +6,7 @@ on:
       - 't*.*.*'
 
 jobs:
-  build:
+  build-and-deploy:
     runs-on: ubuntu-latest
 
     defaults:
@@ -39,28 +39,15 @@ jobs:
           name: angular-build
           path: apl-golf-league/dist/apl-golf-league
 
-  # deploy:
-  #   runs-on: ubuntu-latest
-  #   needs: build  # This job depends on the 'build' job
-
-  #   steps:
-  #     - name: Checkout code
-  #       uses: actions/checkout@v3
-
-  #     - name: Download Build Artifacts
-  #       uses: actions/download-artifact@v3
-  #       with:
-  #         name: angular-build  # The name of the artifact to download
-
-  #     - name: Deploy to HostGator via FTP
-  #       uses: SamKirkland/FTP-Deploy-Action@4.3.0
-  #       with:
-  #         server: ${{ secrets.FTP_HOST }}
-  #         username: ${{ secrets.FTP_USERNAME }}
-  #         password: ${{ secrets.FTP_PASSWORD }}
-  #         port: ${{ secrets.FTP_PORT }}
-  #         local-dir: apl-golf-league/dist/apl-golf-league
-  #         server-dir: /public_html/staging
-  #         protocol: ftp
-  #         log-level: verbose
-  #         dry-run: false
+      - name: Deploy to HostGator via FTP
+        uses: SamKirkland/FTP-Deploy-Action@4.3.0
+        with:
+          server: ${{ secrets.FTP_HOST }}
+          username: ${{ secrets.FTP_USERNAME }}
+          password: ${{ secrets.FTP_PASSWORD }}
+          port: ${{ secrets.FTP_PORT }}
+          local-dir: ./apl-golf-league/dist/apl-golf-league/
+          server-dir: /public_html/staging/
+          protocol: ftp
+          log-level: verbose
+          dry-run: false

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -31,7 +31,7 @@ jobs:
       # TODO: Enable linting checks
 
       - name: Build Angular App
-        run: npm run build -- --configuration=production
+        run: npm run build -- --configuration=staging
 
       - name: Upload Build Artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -20,13 +20,15 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16  # Specify the node version required for your project
+          node-version: 16
 
       - name: Install Dependencies
         run: npm install
 
-      # - name: Run Tests
+      # - name: Run Tests # TODO: Re-enable tests
       #   run: npm test -- --watch=false
+
+      # TODO: Enable linting checks
 
       - name: Build Angular App
         run: npm run build -- --configuration=production
@@ -34,16 +36,12 @@ jobs:
       - name: Upload Build Artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: angular-build  # Name of the artifact
-          path: dist/<your-angular-app>  # Path to the built files, update to match your Angular app's output directory
+          name: angular-build
+          path: apl-golf-league/dist/apl-golf-league
 
   # deploy:
   #   runs-on: ubuntu-latest
   #   needs: build  # This job depends on the 'build' job
-
-  #   defaults:
-  #     run:
-  #       working-directory: ./apl-golf-league
 
   #   steps:
   #     - name: Checkout code
@@ -61,7 +59,7 @@ jobs:
   #         username: ${{ secrets.FTP_USERNAME }}
   #         password: ${{ secrets.FTP_PASSWORD }}
   #         port: ${{ secrets.FTP_PORT }}
-  #         local-dir: dist/<your-angular-app>  # Path to the downloaded artifact folder
+  #         local-dir: apl-golf-league/dist/apl-golf-league
   #         server-dir: /public_html/staging
   #         protocol: ftp
   #         log-level: verbose

--- a/apl-golf-league/angular.json
+++ b/apl-golf-league/angular.json
@@ -61,6 +61,31 @@
                 "output": "index.html"
               }
             },
+            "staging": {
+              "budgets": [
+                {
+                  "type": "initial",
+                  "maximumWarning": "2mb",
+                  "maximumError": "5mb"
+                },
+                {
+                  "type": "anyComponentStyle",
+                  "maximumWarning": "2kb",
+                  "maximumError": "4kb"
+                }
+              ],
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.staging.ts"
+                }
+              ],
+              "outputHashing": "all",
+              "index": {
+                "input": "src/index.prod.html",
+                "output": "index.html"
+              }
+            },
             "development": {
               "buildOptimizer": false,
               "optimization": false,

--- a/apl-golf-league/src/app/header/header.component.html
+++ b/apl-golf-league/src/app/header/header.component.html
@@ -118,7 +118,7 @@
   </mat-menu>
 
   <span class="title">
-    <a routerLink="">APL Golf League</a>
+    <a routerLink="">{{ title }}</a>
   </span>
 
 </mat-toolbar>

--- a/apl-golf-league/src/app/header/header.component.ts
+++ b/apl-golf-league/src/app/header/header.component.ts
@@ -16,6 +16,7 @@ import { SignupComponent } from '../signup/signup.component';
 import { TournamentCreateComponent } from '../tournaments/tournament-create/tournament-create.component';
 import { TournamentsService } from '../tournaments/tournaments.service';
 import { TournamentInfo } from '../shared/tournament.model';
+import { environment } from 'src/environments/environment';
 
 @Component({
   selector: "app-header",
@@ -24,6 +25,8 @@ import { TournamentInfo } from '../shared/tournament.model';
   providers: [SignupComponent]
 })
 export class HeaderComponent implements OnInit, OnDestroy {
+  title = environment.title
+  
   isAuthenticated = false;
   private userSub: Subscription;
   currentUser: User | null = null;

--- a/apl-golf-league/src/environments/environment.prod.ts
+++ b/apl-golf-league/src/environments/environment.prod.ts
@@ -1,4 +1,5 @@
 export const environment = {
   production: true,
-  apiUrl: 'https://aplgolfapi.jaunzenet.com/'
+  apiUrl: 'https://aplgolfapi.jaunzenet.com/',
+  title: "APL Golf League"
 };

--- a/apl-golf-league/src/environments/environment.staging.ts
+++ b/apl-golf-league/src/environments/environment.staging.ts
@@ -1,0 +1,5 @@
+export const environment = {
+  production: true,
+  apiUrl: 'https://aplgolfapi.staging.jaunzenet.com/',
+  title: "APL Golf League - STAGING"
+};

--- a/apl-golf-league/src/environments/environment.ts
+++ b/apl-golf-league/src/environments/environment.ts
@@ -4,7 +4,8 @@
 
 export const environment = {
   production: false,
-  apiUrl: 'http://localhost:80/'
+  apiUrl: 'http://localhost:80/',
+  title: "APL Golf League - DEVELOPMENT"
 };
 
 /*


### PR DESCRIPTION
Adds an Actions workflow triggered by test tags like `tx.y.z*` that builds the angular app, uploads the build artifacts to github, and deploys the build to HostGator over FTP. Also adds a staging app configuration for setting API URL and header title (to indicate staging environment).