### PR TITLE
Add API version to footer

### DIFF
--- a/apl-golf-league/src/app/api/api.service.ts
+++ b/apl-golf-league/src/app/api/api.service.ts
@@ -1,0 +1,30 @@
+import { HttpClient } from "@angular/common/http";
+import { Injectable } from "@angular/core";
+import { Observable, Subject } from "rxjs";
+
+import { APIInfo } from './../shared/api.model';
+import { environment } from './../../environments/environment';
+
+@Injectable({
+  providedIn: "root"
+})
+export class APIService {
+  private info: APIInfo
+  private infoUpdated = new Subject<APIInfo>();
+
+  constructor(private http: HttpClient) {}
+
+  getInfo(): void {
+    this.http.get<APIInfo>(environment.apiUrl)
+      .subscribe(result => {
+        this.info = result;
+        this.infoUpdated.next(this.info);
+      });
+  }
+
+  getInfoUpdateListener(): Observable<APIInfo> {
+    return this.infoUpdated.asObservable();
+  }
+
+}
+

--- a/apl-golf-league/src/app/footer/footer.component.html
+++ b/apl-golf-league/src/app/footer/footer.component.html
@@ -1,6 +1,9 @@
 <footer>
   <div>
-    APL Golf League Website - {{ version }}
+    APL Golf League Website - {{ websiteVersion }}
+  </div>
+  <div>
+    APL Golf League API - {{ apiVersion }}
   </div>
   <div>
     Comments or suggestions?

--- a/apl-golf-league/src/app/footer/footer.component.ts
+++ b/apl-golf-league/src/app/footer/footer.component.ts
@@ -1,5 +1,8 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Subscription } from 'rxjs';
+
 import { environment } from 'src/environments/environment';
+import { APIService } from 'src/app/api/api.service';
 
 @Component({
     selector: 'app-footer',
@@ -7,13 +10,25 @@ import { environment } from 'src/environments/environment';
     styleUrls: ['./footer.component.css'],
     standalone: false
 })
-export class FooterComponent implements OnInit {
+export class FooterComponent implements OnInit, OnDestroy {
 
-  version = environment.version;
+  websiteVersion: string = environment.version;
+  apiVersion: string = "--"
 
-  constructor() { }
+  private apiInfoSub: Subscription;
+
+  constructor(private apiService: APIService) { }
 
   ngOnInit(): void {
+    this.apiInfoSub = this.apiService.getInfoUpdateListener()
+      .subscribe(result => {
+        console.log(`[FooterComponent] Received API info`);
+        this.apiVersion = result.version;
+      })
+  }
+
+  ngOnDestroy(): void {
+    this.apiInfoSub.unsubscribe();
   }
 
 }

--- a/apl-golf-league/src/app/footer/footer.component.ts
+++ b/apl-golf-league/src/app/footer/footer.component.ts
@@ -25,6 +25,7 @@ export class FooterComponent implements OnInit, OnDestroy {
         console.log(`[FooterComponent] Received API info`);
         this.apiVersion = result.version;
       })
+    this.apiService.getInfo();
   }
 
   ngOnDestroy(): void {

--- a/apl-golf-league/src/app/shared/api.model.ts
+++ b/apl-golf-league/src/app/shared/api.model.ts
@@ -1,0 +1,5 @@
+export interface APIInfo {
+    title: string
+    description: string
+    version: string
+}


### PR DESCRIPTION
Adds a line to the webpage footer to display the version of the API that the website is currently connected to. Along with the webpage version for the frontend, useful for ensuring that what is being tested is as expected.