### PR TITLE
Add substitutes to flight signup

### DIFF
--- a/src/app/flights/flight-home/flight-home.component.html
+++ b/src/app/flights/flight-home/flight-home.component.html
@@ -27,7 +27,12 @@
   <div class="hidden xl:block xl:col-span-1 bg-transparent"></div>
 
   <div class="hidden xl:block xl:col-span-1 bg-transparent"></div>
-  <app-flight-teams class="col-span-12 md:col-span- xl:col-span-3" [teams]="teams" *ngIf="teams" />
+  <app-flight-teams
+    class="col-span-12 md:col-span- xl:col-span-3"
+    [teams]="teams"
+    [substitutes]="substitutes"
+    *ngIf="teams && substitutes"
+  />
   <app-flight-statistics
     class="col-span-12 xl:col-span-7"
     [statistics]="statistics"

--- a/src/app/flights/flight-home/flight-home.component.ts
+++ b/src/app/flights/flight-home/flight-home.component.ts
@@ -16,6 +16,7 @@ import {
   FlightStandings,
   FlightStatistics,
   FlightTeam,
+  FlightTeamGolfer,
 } from 'src/app/shared/flight.model';
 import { MatchSummary } from 'src/app/shared/match.model';
 import { FlightStatisticsComponent } from './flight-statistics/flight-statistics.component';
@@ -39,6 +40,7 @@ export class FlightHomeComponent implements OnInit, OnDestroy {
   info: FlightInfo | undefined;
   divisions: FlightDivision[] | undefined;
   teams: FlightTeam[] | undefined;
+  substitutes: FlightTeamGolfer[] | undefined;
   standings: FlightStandings | undefined;
   statistics: FlightStatistics | undefined;
   matches: MatchSummary[] | undefined;
@@ -48,6 +50,7 @@ export class FlightHomeComponent implements OnInit, OnDestroy {
   private flightsService = inject(FlightsService);
   private infoSub: Subscription;
   private teamsSub: Subscription;
+  private substitutesSub: Subscription;
   private standingsSub: Subscription;
   private statisticsSub: Subscription;
   private matchesSub: Subscription;
@@ -63,6 +66,9 @@ export class FlightHomeComponent implements OnInit, OnDestroy {
     this.teamsSub = this.flightsService
       .getTeamsUpdateListener()
       .subscribe((result) => (this.teams = result));
+    this.substitutesSub = this.flightsService
+      .getSubstitutesUpdateListener()
+      .subscribe((result) => (this.substitutes = result));
     this.standingsSub = this.flightsService
       .getStandingsUpdateListener()
       .subscribe((result) => (this.standings = result));
@@ -81,6 +87,7 @@ export class FlightHomeComponent implements OnInit, OnDestroy {
         this.flightsService.getInfo(flightId);
         this.flightsService.getDivisions(flightId);
         this.flightsService.getTeams(flightId);
+        this.flightsService.getSubstitutes(flightId);
         this.flightsService.getStandings(flightId);
         this.flightsService.getStatistics(flightId);
         this.flightsService.getMatches(flightId);
@@ -92,6 +99,7 @@ export class FlightHomeComponent implements OnInit, OnDestroy {
     this.infoSub.unsubscribe();
     this.divisionsSub.unsubscribe();
     this.teamsSub.unsubscribe();
+    this.substitutesSub.unsubscribe();
     this.standingsSub.unsubscribe();
     this.statisticsSub.unsubscribe();
     this.matchesSub.unsubscribe();

--- a/src/app/flights/flight-home/flight-teams/flight-teams.component.html
+++ b/src/app/flights/flight-home/flight-teams/flight-teams.component.html
@@ -8,6 +8,34 @@
     (onOpen)="onTeamSelected($event)"
     (onClose)="onTeamDeselected()"
   >
+    <p-accordion-panel [value]="-1" *ngIf="substitutes.length > 0">
+      <p-accordion-header class="font-semibold px-4 py-2">Substitutes</p-accordion-header>
+      <p-accordion-content>
+        <p-table
+          [value]="substitutes"
+          stripedRows
+          selectionMode="single"
+          dataKey="golfer_id"
+          [(selection)]="selectedGolfer"
+          (onRowSelect)="onGolferSelected()"
+        >
+          <ng-template #header>
+            <tr>
+              <th>Golfer</th>
+              <th>Role</th>
+              <th>Division</th>
+            </tr>
+          </ng-template>
+          <ng-template #body let-golfer>
+            <tr [pSelectableRow]="golfer">
+              <td class="font-semibold text-gray-700">{{ golfer.name }}</td>
+              <td class="text-gray-700">{{ golfer.role }}</td>
+              <td class="text-gray-700">{{ golfer.division }}</td>
+            </tr>
+          </ng-template>
+        </p-table>
+      </p-accordion-content>
+    </p-accordion-panel>
     <p-accordion-panel [value]="idx" *ngFor="let team of teams; let idx = index">
       <p-accordion-header class="font-semibold px-4 py-2">{{ team.name }}</p-accordion-header>
       <p-accordion-content>

--- a/src/app/flights/flight-home/flight-teams/flight-teams.component.ts
+++ b/src/app/flights/flight-home/flight-teams/flight-teams.component.ts
@@ -15,6 +15,7 @@ import { FlightTeam, FlightTeamGolfer } from 'src/app/shared/flight.model';
 })
 export class FlightTeamsComponent {
   @Input() teams: FlightTeam[];
+  @Input() substitutes: FlightTeamGolfer[] = [];
   @Input() linkGolferHome = true;
   @Input() teamMultiSelect = true;
 

--- a/src/app/flights/flight-signup/flight-signup.component.html
+++ b/src/app/flights/flight-signup/flight-signup.component.html
@@ -109,11 +109,17 @@
       <app-team-create
         [allowSubstitutes]="isUserAdmin()"
         [allowDelete]="isUserAdmin()"
+        [golferOptions]="golfers"
         [flightId]="selectedFlight.id"
         [divisionOptions]="selectedFlightDivisions"
         [initialTeam]="selectedTeam"
         (refreshTeamsForFlight)="refreshSelectedFlightTeams($event)"
-        *ngIf="selectedFlightDivisions"
+        *ngIf="selectedFlightDivisions && golfers"
+      />
+      <app-substitutes-signup
+        [substitutes]="selectedFlightSubstitutes"
+        [golferOptions]="golfers"
+        *ngIf="selectedFlightSubstitutes && golfers"
       />
     </div>
   </div>

--- a/src/app/flights/flight-signup/flight-signup.component.html
+++ b/src/app/flights/flight-signup/flight-signup.component.html
@@ -117,6 +117,7 @@
         *ngIf="selectedFlightDivisions && golfers"
       />
       <app-substitutes-signup
+        [allowDelete]="isUserAdmin()"
         [substitutes]="selectedFlightSubstitutes"
         [golferOptions]="golfers"
         [flightId]="selectedFlight.id"

--- a/src/app/flights/flight-signup/flight-signup.component.html
+++ b/src/app/flights/flight-signup/flight-signup.component.html
@@ -119,7 +119,10 @@
       <app-substitutes-signup
         [substitutes]="selectedFlightSubstitutes"
         [golferOptions]="golfers"
-        *ngIf="selectedFlightSubstitutes && golfers"
+        [flightId]="selectedFlight.id"
+        [divisionOptions]="selectedFlightDivisions"
+        (refreshTeamsForFlight)="refreshSelectedFlightTeams($event)"
+        *ngIf="selectedFlightSubstitutes && selectedFlightDivisions && golfers"
       />
     </div>
   </div>

--- a/src/app/flights/flight-signup/substitutes-signup/substitutes-signup.component.html
+++ b/src/app/flights/flight-signup/substitutes-signup/substitutes-signup.component.html
@@ -10,6 +10,43 @@
     >
   </div>
 
+  <p-inputgroup class="pb-4">
+    <p-inputgroup-addon><i class="pi pi-user"></i></p-inputgroup-addon>
+
+    <p-select
+      class="ring-1 ring-gray-200 bg-gray-50 rounded-md text-left h-8 w-40 ml-2 pl-2 py-1"
+      [options]="golferOptions"
+      [(ngModel)]="newGolfer"
+      optionLabel="name"
+      [filter]="true"
+      filterBy="name"
+      placeholder="Golfer"
+    >
+      <ng-template #selectedItem let-selectedOption>
+        <div class="flex items-center gap-2">
+          <div>{{ selectedOption.name }}</div>
+        </div>
+      </ng-template>
+      <ng-template let-golfer #item>
+        <div class="flex items-center gap-2">
+          <div>{{ golfer.name }}</div>
+        </div>
+      </ng-template>
+    </p-select>
+
+    <p-select
+      class="ring-1 ring-gray-200 bg-gray-50 rounded-md text-left h-8 w-28 ml-2 pl-2 py-1"
+      [options]="divisionOptions"
+      [(ngModel)]="newGolferDivision"
+      optionLabel="name"
+      placeholder="Division"
+    />
+
+    <p-button (click)="addGolfer()">
+      <span class="pi pi-plus text-sm"></span>
+    </p-button>
+  </p-inputgroup>
+
   <p-accordion>
     <p-accordion-panel [value]="0">
       <p-accordion-header class="font-semibold px-4 py-2"
@@ -18,43 +55,6 @@
         }})</p-accordion-header
       >
       <p-accordion-content>
-        <p-inputgroup class="p-4">
-          <p-inputgroup-addon><i class="pi pi-user"></i></p-inputgroup-addon>
-
-          <p-select
-            class="ring-1 ring-gray-200 bg-gray-50 rounded-md text-left h-8 w-40 ml-2 pl-2 py-1"
-            [options]="golferOptions"
-            [(ngModel)]="newGolfer"
-            optionLabel="name"
-            [filter]="true"
-            filterBy="name"
-            placeholder="Golfer"
-          >
-            <ng-template #selectedItem let-selectedOption>
-              <div class="flex items-center gap-2">
-                <div>{{ selectedOption.name }}</div>
-              </div>
-            </ng-template>
-            <ng-template let-golfer #item>
-              <div class="flex items-center gap-2">
-                <div>{{ golfer.name }}</div>
-              </div>
-            </ng-template>
-          </p-select>
-
-          <p-select
-            class="ring-1 ring-gray-200 bg-gray-50 rounded-md text-left h-8 w-28 ml-2 pl-2 py-1"
-            [options]="divisionOptions"
-            [(ngModel)]="newGolferDivision"
-            optionLabel="name"
-            placeholder="Division"
-          />
-
-          <p-button (click)="addGolfer()">
-            <span class="pi pi-plus text-sm"></span>
-          </p-button>
-        </p-inputgroup>
-
         <p-table [value]="substitutes" dataKey="golfer_id" *ngIf="substitutes.length > 0">
           <ng-template #header>
             <tr>

--- a/src/app/flights/flight-signup/substitutes-signup/substitutes-signup.component.html
+++ b/src/app/flights/flight-signup/substitutes-signup/substitutes-signup.component.html
@@ -70,7 +70,12 @@
               <td class="text-gray-700">{{ golfer.role }}</td>
               <td class="text-gray-700">{{ golfer.division }}</td>
               <td>
-                <p-button icon="pi pi-minus text-sm" (click)="removeGolfer(golfer)" rounded />
+                <p-button
+                  icon="pi pi-minus text-sm"
+                  (click)="removeGolfer(golfer)"
+                  rounded
+                  *ngIf="allowDelete"
+                />
               </td>
             </tr>
           </ng-template>

--- a/src/app/flights/flight-signup/substitutes-signup/substitutes-signup.component.html
+++ b/src/app/flights/flight-signup/substitutes-signup/substitutes-signup.component.html
@@ -1,0 +1,81 @@
+<p-card>
+  <div class="flex flex-col items-start px-4 py-4">
+    <span class="text-2xl font-semibold">Substitutes</span>
+
+    <span class="font-normal pt-2"
+      >Golfers willing to substitute for unavailable regular team members.</span
+    >
+    <span class="font-normal"
+      >Substitutes cannot be regular members on another team in the same flight.</span
+    >
+  </div>
+
+  <p-accordion>
+    <p-accordion-panel [value]="0">
+      <p-accordion-header class="font-semibold px-4 py-2"
+        >Roster ({{ substitutes.length }} golfer{{
+          substitutes.length !== 1 ? 's' : ''
+        }})</p-accordion-header
+      >
+      <p-accordion-content>
+        <p-inputgroup class="p-4">
+          <p-inputgroup-addon><i class="pi pi-user"></i></p-inputgroup-addon>
+
+          <p-select
+            class="ring-1 ring-gray-200 bg-gray-50 rounded-md text-left h-8 w-40 ml-2 pl-2 py-1"
+            [options]="golferOptions"
+            [(ngModel)]="newGolfer"
+            optionLabel="name"
+            [filter]="true"
+            filterBy="name"
+            placeholder="Golfer"
+          >
+            <ng-template #selectedItem let-selectedOption>
+              <div class="flex items-center gap-2">
+                <div>{{ selectedOption.name }}</div>
+              </div>
+            </ng-template>
+            <ng-template let-golfer #item>
+              <div class="flex items-center gap-2">
+                <div>{{ golfer.name }}</div>
+              </div>
+            </ng-template>
+          </p-select>
+
+          <p-select
+            class="ring-1 ring-gray-200 bg-gray-50 rounded-md text-left h-8 w-28 ml-2 pl-2 py-1"
+            [options]="divisionOptions"
+            [(ngModel)]="newGolferDivision"
+            optionLabel="name"
+            placeholder="Division"
+          />
+
+          <p-button (click)="addGolfer()">
+            <span class="pi pi-plus text-sm"></span>
+          </p-button>
+        </p-inputgroup>
+
+        <p-table [value]="substitutes" dataKey="golfer_id" *ngIf="substitutes.length > 0">
+          <ng-template #header>
+            <tr>
+              <th>Golfer</th>
+              <th>Role</th>
+              <th>Division</th>
+              <th class="w-4"></th>
+            </tr>
+          </ng-template>
+          <ng-template #body let-golfer>
+            <tr [pSelectableRow]="golfer">
+              <td class="font-semibold text-gray-700">{{ golfer.name }}</td>
+              <td class="text-gray-700">{{ golfer.role }}</td>
+              <td class="text-gray-700">{{ golfer.division }}</td>
+              <td>
+                <p-button icon="pi pi-minus text-sm" (click)="removeGolfer(golfer)" rounded />
+              </td>
+            </tr>
+          </ng-template>
+        </p-table>
+      </p-accordion-content>
+    </p-accordion-panel>
+  </p-accordion>
+</p-card>

--- a/src/app/flights/flight-signup/substitutes-signup/substitutes-signup.component.ts
+++ b/src/app/flights/flight-signup/substitutes-signup/substitutes-signup.component.ts
@@ -63,11 +63,11 @@ export class SubstitutesSignupComponent implements OnInit, OnChanges {
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['golferOptions'] || changes['flightId']) {
-      // this.clearNewSubstitute();
+      this.clearNewSubstitute();
     }
 
     if (changes['divisionOptions']) {
-      // this.clearNewSubstitute();
+      this.clearNewSubstitute();
       this.updateDivisionIdMap();
     }
   }

--- a/src/app/flights/flight-signup/substitutes-signup/substitutes-signup.component.ts
+++ b/src/app/flights/flight-signup/substitutes-signup/substitutes-signup.component.ts
@@ -43,6 +43,8 @@ import { NotificationService } from 'src/app/notifications/notification.service'
 export class SubstitutesSignupComponent implements OnInit, OnChanges {
   @Output() refreshTeamsForFlight = new EventEmitter<number>();
 
+  @Input() allowDelete = false;
+
   @Input() substitutes: FlightTeamGolfer[];
 
   @Input() golferOptions: Golfer[];

--- a/src/app/flights/flight-signup/substitutes-signup/substitutes-signup.component.ts
+++ b/src/app/flights/flight-signup/substitutes-signup/substitutes-signup.component.ts
@@ -1,0 +1,67 @@
+import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { ButtonModule } from 'primeng/button';
+import { CardModule } from 'primeng/card';
+import { InputGroupModule } from 'primeng/inputgroup';
+import { InputGroupAddonModule } from 'primeng/inputgroupaddon';
+import { SelectModule } from 'primeng/select';
+import { TableModule } from 'primeng/table';
+import { AccordionModule } from 'primeng/accordion';
+
+import { FlightDivision, FlightTeamGolfer } from 'src/app/shared/flight.model';
+import { Golfer } from 'src/app/shared/golfer.model';
+
+@Component({
+  selector: 'app-substitutes-signup',
+  templateUrl: './substitutes-signup.component.html',
+  styleUrl: './substitutes-signup.component.css',
+  imports: [
+    CommonModule,
+    FormsModule,
+    CardModule,
+    InputGroupModule,
+    InputGroupAddonModule,
+    SelectModule,
+    ButtonModule,
+    TableModule,
+    AccordionModule,
+  ],
+})
+export class SubstitutesSignupComponent implements OnChanges {
+  @Output() refreshTeamsForFlight = new EventEmitter<number>();
+
+  @Input() substitutes: FlightTeamGolfer[];
+
+  @Input() golferOptions: Golfer[];
+
+  @Input() flightId: number;
+  @Input() divisionOptions: FlightDivision[];
+
+  newGolfer: Golfer | null = null;
+  newGolferDivision: FlightDivision | null = null;
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['golferOptions'] || changes['flightId'] || changes['divisionOptions']) {
+      // this.clearNewSubstitute();
+    }
+  }
+
+  addGolfer(): void {
+    if (!this.newGolfer || !this.newGolferDivision) {
+      return;
+    }
+
+    // TODO: Send HTTP request
+
+    // this.clearNewSubstitute();
+  }
+
+  removeGolfer(golfer: FlightTeamGolfer): void {
+    this.substitutes = this.substitutes.filter(
+      (substitute) => substitute.golfer_id !== golfer.golfer_id,
+    );
+
+    // TODO: Send HTTP request
+  }
+}

--- a/src/app/flights/flights.service.ts
+++ b/src/app/flights/flights.service.ts
@@ -11,6 +11,7 @@ import {
   FlightStandings,
   FlightTeam,
   FlightStatistics,
+  FlightTeamGolfer,
 } from '../shared/flight.model';
 import { TeamDataWithMatches } from '../shared/team.model';
 import { environment } from './../../environments/environment';
@@ -31,6 +32,9 @@ export class FlightsService {
 
   private flightTeams: FlightTeam[];
   private flightTeamsUpdated = new Subject<FlightTeam[]>();
+
+  private flightSubstitutes: FlightTeamGolfer[];
+  private flightSubstitutesUpdated = new Subject<FlightTeamGolfer[]>();
 
   private flightStandings: FlightStandings;
   private flightStandingsUpdated = new Subject<FlightStandings>();
@@ -129,6 +133,19 @@ export class FlightsService {
 
   getTeamsUpdateListener(): Observable<FlightTeam[]> {
     return this.flightTeamsUpdated.asObservable();
+  }
+
+  getSubstitutes(id: number): void {
+    this.http
+      .get<FlightTeamGolfer[]>(environment.apiUrl + `flights/substitutes/${id}`)
+      .subscribe((result) => {
+        this.flightSubstitutes = result;
+        this.flightSubstitutesUpdated.next(result);
+      });
+  }
+
+  getSubstitutesUpdateListener(): Observable<FlightTeamGolfer[]> {
+    return this.flightSubstitutesUpdated.asObservable();
   }
 
   getStandings(id: number): void {

--- a/src/app/shared/substitute.model.ts
+++ b/src/app/shared/substitute.model.ts
@@ -1,0 +1,5 @@
+export interface Substitute {
+  flight_id: number;
+  golfer_id: number;
+  division_id: number;
+}

--- a/src/app/teams/team-create/team-create.component.ts
+++ b/src/app/teams/team-create/team-create.component.ts
@@ -4,13 +4,11 @@ import {
   inject,
   Input,
   OnChanges,
-  OnDestroy,
   OnInit,
   Output,
   SimpleChanges,
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { Observable, Subscription } from 'rxjs';
 import { CardModule } from 'primeng/card';
 import { InputGroupModule } from 'primeng/inputgroup';
 import { InputGroupAddonModule } from 'primeng/inputgroupaddon';
@@ -21,7 +19,6 @@ import { TableModule } from 'primeng/table';
 
 import { NotificationService } from '../../notifications/notification.service';
 import { Golfer } from '../../shared/golfer.model';
-import { GolfersService } from '../../golfers/golfers.service';
 import { CommonModule } from '@angular/common';
 import { FlightDivision, FlightTeam, FlightTeamGolfer } from 'src/app/shared/flight.model';
 import { TeamsService } from '../teams.service';
@@ -43,11 +40,13 @@ import { TeamCreate, TeamGolferCreate } from 'src/app/shared/team.model';
     TableModule,
   ],
 })
-export class TeamCreateComponent implements OnInit, OnDestroy, OnChanges {
+export class TeamCreateComponent implements OnInit, OnChanges {
   @Output() refreshTeamsForFlight = new EventEmitter<number>();
 
   @Input() allowSubstitutes = false;
   @Input() allowDelete = false;
+
+  @Input() golferOptions: Golfer[] = [];
 
   @Input() flightId: number;
   @Input() divisionOptions: FlightDivision[];
@@ -66,12 +65,6 @@ export class TeamCreateComponent implements OnInit, OnDestroy, OnChanges {
 
   private divisionNameToId: Record<string, number> = {};
 
-  golferOptions: Golfer[] = [];
-  golferNameOptions: string[] = [];
-  filteredGolferOptionsArray: Observable<Golfer[]>[] = [];
-  private golfersSub: Subscription;
-  private golfersService = inject(GolfersService);
-
   private teamsService = inject(TeamsService);
 
   private notificationService = inject(NotificationService);
@@ -81,32 +74,13 @@ export class TeamCreateComponent implements OnInit, OnDestroy, OnChanges {
       this.roleOptions.push('Substitute');
     }
 
-    this.golfersSub = this.golfersService.getAllGolfersUpdateListener().subscribe((result) => {
-      this.golferOptions = result.sort((a: Golfer, b: Golfer) => {
-        if (a.name < b.name) {
-          return -1;
-        }
-        if (a.name > b.name) {
-          return 1;
-        }
-        return 0;
-      });
-      this.golferNameOptions = result.map((golfer) => golfer.name);
-    });
-
-    this.golfersService.getAllGolfers();
-
     for (const d of this.divisionOptions) {
       this.divisionNameToId[d.name] = d.id;
     }
   }
 
-  ngOnDestroy(): void {
-    this.golfersSub.unsubscribe();
-  }
-
   ngOnChanges(changes: SimpleChanges): void {
-    if (changes['flightId']) {
+    if (changes['golferOptions'] || changes['flightId'] || changes['divisionOptions']) {
       this.clear();
     }
     if (changes['initialTeam']) {

--- a/src/app/teams/team-create/team-create.component.ts
+++ b/src/app/teams/team-create/team-create.component.ts
@@ -50,6 +50,7 @@ export class TeamCreateComponent implements OnInit, OnChanges {
 
   @Input() flightId: number;
   @Input() divisionOptions: FlightDivision[];
+  private divisionNameToId: Record<string, number> = {};
 
   @Input() initialTeam: FlightTeam | null;
   teamId: number | null = null;
@@ -63,8 +64,6 @@ export class TeamCreateComponent implements OnInit, OnChanges {
 
   roleOptions = ['Captain', 'Player'];
 
-  private divisionNameToId: Record<string, number> = {};
-
   private teamsService = inject(TeamsService);
 
   private notificationService = inject(NotificationService);
@@ -74,21 +73,32 @@ export class TeamCreateComponent implements OnInit, OnChanges {
       this.roleOptions.push('Substitute');
     }
 
-    for (const d of this.divisionOptions) {
-      this.divisionNameToId[d.name] = d.id;
-    }
+    this.updateDivisionIdMap();
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    if (changes['golferOptions'] || changes['flightId'] || changes['divisionOptions']) {
+    if (changes['golferOptions'] || changes['flightId']) {
       this.clear();
     }
+
+    if (changes['divisionOptions']) {
+      this.clear();
+      this.updateDivisionIdMap();
+    }
+
     if (changes['initialTeam']) {
       this.clear();
       this.teamId = null;
       if (changes['initialTeam'].currentValue !== null) {
         this.refreshFromTeam(changes['initialTeam'].currentValue as FlightTeam);
       }
+    }
+  }
+
+  private updateDivisionIdMap(): void {
+    this.divisionNameToId = {};
+    for (const d of this.divisionOptions) {
+      this.divisionNameToId[d.name] = d.id;
     }
   }
 

--- a/src/app/teams/teams.service.ts
+++ b/src/app/teams/teams.service.ts
@@ -5,6 +5,7 @@ import { Observable } from 'rxjs';
 
 import { environment } from './../../environments/environment';
 import { TeamCreate } from '../shared/team.model';
+import { Substitute } from '../shared/substitute.model';
 
 @Injectable({
   providedIn: 'root',
@@ -51,5 +52,16 @@ export class TeamsService {
 
   deleteTeam(teamId: number): Observable<{ id: number; name: string }> {
     return this.http.delete<{ id: number; name: string }>(environment.apiUrl + `teams/${teamId}`);
+  }
+
+  addSubstitute(substitute: Substitute): Observable<Substitute> {
+    return this.http.post<Substitute>(environment.apiUrl + `substitutes/`, substitute);
+  }
+
+  deleteSubstitute(substitute: Substitute): Observable<Substitute> {
+    return this.http.delete<Substitute>(
+      environment.apiUrl +
+        `substitutes/?flight_id=${substitute.flight_id}&golfer_id=${substitute.golfer_id}`,
+    );
   }
 }


### PR DESCRIPTION
This PR adds a substitute signup component to the flight signup page, allowing users to add golfers to a substitute roster for the flight and allowing admins to manage the list by removing entries.