### PR TITLE
Enable substitutes for use in matches

### DIFF
--- a/src/app/flights/flight-home/flight-teams/flight-teams.component.html
+++ b/src/app/flights/flight-home/flight-teams/flight-teams.component.html
@@ -20,6 +20,11 @@
     <p-accordion-panel [value]="-1" *ngIf="substitutes.length > 0">
       <p-accordion-header class="font-semibold px-4 py-2">Substitutes</p-accordion-header>
       <p-accordion-content>
+        <div class="flex flex-col items-end w-full py-1">
+          <a class="p-button contactButton" href="mailto:{{ getSubstitutesEmailList() }}">
+            <span class="text-sm pi pi-send"></span>
+          </a>
+        </div>
         <p-table
           [value]="substitutes"
           stripedRows

--- a/src/app/flights/flight-home/flight-teams/flight-teams.component.ts
+++ b/src/app/flights/flight-home/flight-teams/flight-teams.component.ts
@@ -62,4 +62,14 @@ export class FlightTeamsComponent {
     }
     return emailList.substring(0, emailList.length - 1);
   }
+
+  getSubstitutesEmailList(): string {
+    let emailList = '';
+    for (const golfer of this.substitutes) {
+      if (golfer.email) {
+        emailList += golfer.email + ';';
+      }
+    }
+    return emailList.substring(0, emailList.length - 1);
+  }
 }

--- a/src/app/flights/flight-match-create/flight-match-create.component.html
+++ b/src/app/flights/flight-match-create/flight-match-create.component.html
@@ -212,14 +212,19 @@
           *ngIf="selectedTeam1"
         >
           <ng-template #selectedItem let-selectedGolfer>
-            <div class="flex items-center gap-2">
-              <div>{{ selectedGolfer.golfer_name }}</div>
-            </div>
+            <span>{{ selectedGolfer.golfer_name }}</span>
+            <span class="italic" *ngIf="selectedGolfer.role === 'Substitute'"> (sub.)</span>
           </ng-template>
           <ng-template let-golferOption #item>
-            <div class="flex items-center gap-2">
-              <div>{{ golferOption.golfer_name }}</div>
-            </div>
+            <span
+              [ngClass]="
+                golferOption.role === 'Substitute' ? 'italic text-gray-700' : 'font-normal'
+              "
+              >{{ golferOption.golfer_name }}</span
+            >
+            <span class="italic text-gray-700 pl-1" *ngIf="golferOption.role === 'Substitute'">
+              (substitute)</span
+            >
           </ng-template>
         </p-select>
 
@@ -233,11 +238,9 @@
           *ngIf="selectedTrack && selectedTeam1Golfer1"
         >
           <ng-template #selectedItem let-selectedTee>
-            <div class="flex items-center gap-2">
-              <div>
-                {{ selectedTee.name }} ({{ selectedTee.gender | slice: 0 : 1 }}:
-                {{ selectedTee.rating | number: '1.1-1' }}/{{ selectedTee.slope }})
-              </div>
+            <div>
+              {{ selectedTee.name }} ({{ selectedTee.gender | slice: 0 : 1 }}:
+              {{ selectedTee.rating | number: '1.1-1' }}/{{ selectedTee.slope }})
             </div>
           </ng-template>
           <ng-template let-teeOption #item>
@@ -262,14 +265,19 @@
           *ngIf="selectedTeam1"
         >
           <ng-template #selectedItem let-selectedGolfer>
-            <div class="flex items-center gap-2">
-              <div>{{ selectedGolfer.golfer_name }}</div>
-            </div>
+            <span>{{ selectedGolfer.golfer_name }}</span>
+            <span class="italic" *ngIf="selectedGolfer.role === 'Substitute'"> (sub.)</span>
           </ng-template>
           <ng-template let-golferOption #item>
-            <div class="flex items-center gap-2">
-              <div>{{ golferOption.golfer_name }}</div>
-            </div>
+            <span
+              [ngClass]="
+                golferOption.role === 'Substitute' ? 'italic text-gray-700' : 'font-normal'
+              "
+              >{{ golferOption.golfer_name }}</span
+            >
+            <span class="italic text-gray-700 pl-1" *ngIf="golferOption.role === 'Substitute'">
+              (substitute)</span
+            >
           </ng-template>
         </p-select>
 
@@ -333,14 +341,19 @@
           *ngIf="selectedTeam2"
         >
           <ng-template #selectedItem let-selectedGolfer>
-            <div class="flex items-center gap-2">
-              <div>{{ selectedGolfer.golfer_name }}</div>
-            </div>
+            <span>{{ selectedGolfer.golfer_name }}</span>
+            <span class="italic" *ngIf="selectedGolfer.role === 'Substitute'"> (sub.)</span>
           </ng-template>
           <ng-template let-golferOption #item>
-            <div class="flex items-center gap-2">
-              <div>{{ golferOption.golfer_name }}</div>
-            </div>
+            <span
+              [ngClass]="
+                golferOption.role === 'Substitute' ? 'italic text-gray-700' : 'font-normal'
+              "
+              >{{ golferOption.golfer_name }}</span
+            >
+            <span class="italic text-gray-700 pl-1" *ngIf="golferOption.role === 'Substitute'">
+              (substitute)</span
+            >
           </ng-template>
         </p-select>
 
@@ -383,14 +396,19 @@
           *ngIf="selectedTeam2"
         >
           <ng-template #selectedItem let-selectedGolfer>
-            <div class="flex items-center gap-2">
-              <div>{{ selectedGolfer.golfer_name }}</div>
-            </div>
+            <span>{{ selectedGolfer.golfer_name }}</span>
+            <span class="italic" *ngIf="selectedGolfer.role === 'Substitute'"> (sub.)</span>
           </ng-template>
           <ng-template let-golferOption #item>
-            <div class="flex items-center gap-2">
-              <div>{{ golferOption.golfer_name }}</div>
-            </div>
+            <span
+              [ngClass]="
+                golferOption.role === 'Substitute' ? 'italic text-gray-700' : 'font-normal'
+              "
+              >{{ golferOption.golfer_name }}</span
+            >
+            <span class="italic text-gray-700 pl-1" *ngIf="golferOption.role === 'Substitute'">
+              (substitute)</span
+            >
           </ng-template>
         </p-select>
 


### PR DESCRIPTION
This PR adds the ability to select substitute golfers from a flight for any match scorecard generation and score entry. A "contact" button is also added to the substitute roster.

A small bug exists where viewing the scorecard for a match that used a sub doesn't show the sub's round unless they are explicitly added as a sub for the team roster. Should update match/round retrieval in the backend to handle this better.