### PR TITLE
Update to link matches and rounds to teams directly

### DIFF
--- a/src/app/flights/flight-home/flight-statistics/flight-statistics.component.html
+++ b/src/app/flights/flight-home/flight-statistics/flight-statistics.component.html
@@ -17,6 +17,7 @@
       [onLabel]="labelShowSubstitutesOn"
       [offLabel]="labelShowSubstitutesOff"
       (onChange)="onChangeShowSubstitutes($event)"
+      *ngIf="!hideSubstitutesToggle"
     />
 
     <p-togglebutton

--- a/src/app/flights/flight-home/flight-statistics/flight-statistics.component.ts
+++ b/src/app/flights/flight-home/flight-statistics/flight-statistics.component.ts
@@ -34,6 +34,7 @@ export class FlightStatisticsComponent implements OnInit {
   labelScoringModeGross = 'Scoring Mode: Gross';
   labelScoringModeNet = 'Scoring Mode: Net';
 
+  @Input() hideSubstitutesToggle = false;
   showSubstitutes = false;
   labelShowSubstitutesOn = 'Substitutes: Include';
   labelShowSubstitutesOff = 'Substitutes: Exclude';

--- a/src/app/flights/team-home/team-home.component.html
+++ b/src/app/flights/team-home/team-home.component.html
@@ -26,6 +26,7 @@
     class="col-span-12 md:col-span-6"
     [statistics]="statistics"
     [matchCountLimit]="0"
+    [hideSubstitutesToggle]="true"
     [pagination]="false"
     *ngIf="statistics"
   />


### PR DESCRIPTION
This PR corresponds to a backend update to directly link matches, rounds, and teams together, instead of inferring through teamgolferlink. For the frontend, a paired update to toggle the substitute exclusion in stats is included.