### PR TITLE
Add shamble tournament scoring mode option

### DIFF
--- a/src/app/shared/tournament.model.ts
+++ b/src/app/shared/tournament.model.ts
@@ -46,6 +46,7 @@ export interface TournamentInfo {
   strokeplay: boolean;
   bestball: number;
   scramble: boolean;
+  shamble: boolean;
   ryder_cup: boolean;
   individual: boolean;
   chachacha: boolean;

--- a/src/app/shared/tournament.model.ts
+++ b/src/app/shared/tournament.model.ts
@@ -22,6 +22,7 @@ export interface TournamentData {
   strokeplay: boolean;
   bestball: number;
   scramble: boolean;
+  shamble: boolean;
   ryder_cup: boolean;
   individual: boolean;
   chachacha: boolean;
@@ -71,6 +72,7 @@ export interface TournamentCreate {
   shotgun: boolean;
   strokeplay: boolean;
   scramble: boolean;
+  shamble: boolean;
   individual: boolean;
   ryder_cup: boolean;
   chachacha: boolean;

--- a/src/app/tournaments/tournament-create/tournament-create.component.html
+++ b/src/app/tournaments/tournament-create/tournament-create.component.html
@@ -144,6 +144,8 @@
 
       <mat-checkbox class="checkbox-field" [formControl]="scrambleControl">Scramble</mat-checkbox>
 
+      <mat-checkbox class="checkbox-field" [formControl]="shambleControl">Shamble</mat-checkbox>
+
       <mat-checkbox class="checkbox-field" [formControl]="individualControl"
         >Individual</mat-checkbox
       >

--- a/src/app/tournaments/tournament-create/tournament-create.component.ts
+++ b/src/app/tournaments/tournament-create/tournament-create.component.ts
@@ -62,6 +62,9 @@ export class TournamentCreateComponent implements OnInit, OnDestroy {
   scrambleControl: UntypedFormControl = new UntypedFormControl(this.data.scramble, [
     Validators.required,
   ]);
+  shambleControl: UntypedFormControl = new UntypedFormControl(this.data.shamble, [
+    Validators.required,
+  ]);
   individualControl: UntypedFormControl = new UntypedFormControl(this.data.individual, [
     Validators.required,
   ]);
@@ -257,6 +260,7 @@ export class TournamentCreateComponent implements OnInit, OnDestroy {
       shotgun: this.shotgunControl.value,
       strokeplay: this.strokeplayControl.value,
       scramble: this.scrambleControl.value,
+      shamble: this.shambleControl.value,
       ryder_cup: this.ryderCupControl.value,
       individual: this.individualControl.value,
       chachacha: this.chachachaControl.value,

--- a/src/app/tournaments/tournament-home/tournament-info/tournament-info.component.ts
+++ b/src/app/tournaments/tournament-home/tournament-info/tournament-info.component.ts
@@ -36,6 +36,9 @@ export class TournamentInfoComponent {
     if (this.info.scramble) {
       modes.push('Scramble');
     }
+    if (this.info.shamble) {
+      modes.push('Shamble');
+    }
     if (this.info.bestball > 0) {
       if (this.info.bestball == 1) {
         modes.push('Best Ball');


### PR DESCRIPTION
This PR adds shamble as a property of the Tournament data models and creation/edit page, and notes its selection in the tournament info panel.