### PR TITLE
Allow admin login in maintenance mode

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -1,7 +1,6 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
-import { environment } from 'src/environments/environment';
 import { AuthGuard } from './auth/auth.guard';
 import { LeagueHomeComponent } from './league-home/league-home.component';
 import { FlightMatchScorecardComponent } from './flights/flight-match-create/flight-match-scorecard.component';
@@ -13,19 +12,21 @@ import { GolferSearchComponent } from './golfers/golfer-search/golfer-search.com
 import { PrimeNGExampleComponent } from './primeng/primeng-example.component';
 import { FlightHomeComponent } from './flights/flight-home/flight-home.component';
 import { TeamHomeComponent } from './flights/team-home/team-home.component';
-import { MaintenanceComponent } from './maintenance/maintenance.component';
 import { FlightSignupComponent } from './flights/flight-signup/flight-signup.component';
 import { TournamentSignupComponent } from './tournaments/tournament-signup/tournament-signup.component';
 import { TournamentHomeComponent } from './tournaments/tournament-home/tournament-home.component';
 import { UnderConstructionComponent } from './maintenance/under-construction/under-construction.component';
 import { UnderConstructionGuard } from './maintenance/under-construction/under-construction.guard';
+import { MaintenanceComponent } from './maintenance/maintenance.component';
+import { MaintenanceGuard } from './maintenance/maintenance.guard';
 
-const routes: Routes = environment.maintenance
-  ? [
-      { path: 'maintenance', component: MaintenanceComponent },
-      { path: '**', redirectTo: 'maintenance' },
-    ]
-  : [
+const routes: Routes = [
+  { path: 'auth/login', component: LoginComponent },
+  { path: 'maintenance', component: MaintenanceComponent},
+  {
+    path: '',
+    canActivateChild: [MaintenanceGuard],
+    children: [
       { path: '', component: LeagueHomeComponent },
       { path: 'under-construction', component: UnderConstructionComponent },
       { path: 'flight', component: FlightHomeComponent },
@@ -76,9 +77,10 @@ const routes: Routes = environment.maintenance
       // },
       { path: 'handicaps', component: HandicapsComponent, canActivate: [UnderConstructionGuard] },
       { path: 'primeng-example', component: PrimeNGExampleComponent, canActivate: [AuthGuard] },
-      { path: '**', redirectTo: '' },
-    ];
-
+    ]
+  },
+  { path: '**', redirectTo: '' },
+]
 @NgModule({
   imports: [RouterModule.forRoot(routes)],
   exports: [RouterModule],

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -22,7 +22,7 @@ import { MaintenanceGuard } from './maintenance/maintenance.guard';
 
 const routes: Routes = [
   { path: 'auth/login', component: LoginComponent },
-  { path: 'maintenance', component: MaintenanceComponent},
+  { path: 'maintenance', component: MaintenanceComponent },
   {
     path: '',
     canActivateChild: [MaintenanceGuard],
@@ -77,10 +77,10 @@ const routes: Routes = [
       // },
       { path: 'handicaps', component: HandicapsComponent, canActivate: [UnderConstructionGuard] },
       { path: 'primeng-example', component: PrimeNGExampleComponent, canActivate: [AuthGuard] },
-    ]
+    ],
   },
   { path: '**', redirectTo: '' },
-]
+];
 @NgModule({
   imports: [RouterModule.forRoot(routes)],
   exports: [RouterModule],

--- a/src/app/footer/footer.component.ts
+++ b/src/app/footer/footer.component.ts
@@ -19,10 +19,6 @@ export class FooterComponent implements OnInit, OnDestroy {
   private apiInfoSub: Subscription;
 
   ngOnInit(): void {
-    if (environment.maintenance) {
-      return;
-    }
-
     this.apiInfoSub = this.apiService.getInfoUpdateListener().subscribe((result) => {
       console.log(`[FooterComponent] Received API info`);
       this.apiVersion = result.version;

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -38,30 +38,28 @@
     }
   </ng-template>
 
-  @if (!maintenance) {
-    <ng-template #end>
-      <div class="flex flex-row items-center mx-4">
-        <p-button class="pr-4" (click)="themeService.toggleTheme()">
-          @if (themeService.isDark()) {
-            <span class="pi pi-moon"></span>
-          }
-          @if (!themeService.isDark()) {
-            <span class="pi pi-sun"></span>
-          }
-        </p-button>
-        @if (isAuthenticated) {
-          <!-- TODO: Add profile page here? Routerlink: /auth/user -->
-          <button (click)="onLogout()" class="p-menubar-item-link">
-            <span class="pi pi-sign-out"></span>
-            <span>Logout</span>
-          </button>
-        } @else {
-          <a routerLink="/auth/login" class="p-menubar-item-link">
-            <span class="pi pi-sign-in"></span>
-            <span>Login</span>
-          </a>
+  <ng-template #end>
+    <div class="flex flex-row items-center mx-4">
+      <p-button class="pr-4" (click)="themeService.toggleTheme()">
+        @if (themeService.isDark()) {
+          <span class="pi pi-moon"></span>
         }
-      </div>
-    </ng-template>
-  }
+        @if (!themeService.isDark()) {
+          <span class="pi pi-sun"></span>
+        }
+      </p-button>
+      @if (isAuthenticated) {
+        <!-- TODO: Add profile page here? Routerlink: /auth/user -->
+        <button (click)="onLogout()" class="p-menubar-item-link">
+          <span class="pi pi-sign-out"></span>
+          <span>Logout</span>
+        </button>
+      } @else {
+        <a routerLink="/auth/login" class="p-menubar-item-link">
+          <span class="pi pi-sign-in"></span>
+          <span>Login</span>
+        </a>
+      }
+    </div>
+  </ng-template>
 </p-menubar>

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -51,10 +51,6 @@ export class HeaderComponent implements OnInit, OnDestroy {
   private teamCreateComponent = inject(TeamCreateComponent);
 
   ngOnInit(): void {
-    if (this.maintenance) {
-      return;
-    }
-
     this.updateMenuItems();
 
     this.userSub = this.authService.user.subscribe((user) => {
@@ -91,7 +87,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
       {
         label: 'Search',
         icon: 'pi pi-search',
-        visible: true,
+        visible: this.currentUser?.is_admin || !this.maintenance,
         items: [
           {
             label: 'Golfers',
@@ -110,7 +106,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
       {
         label: 'Sign-Ups',
         icon: 'pi pi-clipboard',
-        visible: true,
+        visible: this.currentUser?.is_admin || !this.maintenance,
         items: [
           {
             label: 'Register Golfer',
@@ -135,7 +131,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
       {
         label: 'Payments',
         icon: 'pi pi-dollar',
-        visible: true,
+        visible: this.currentUser?.is_admin || !this.maintenance,
         items: [
           {
             label: 'League Dues',
@@ -154,7 +150,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
       {
         label: 'Scorecards',
         icon: 'pi pi-pen-to-square',
-        visible: true,
+        visible: this.currentUser?.is_admin || !this.maintenance,
         items: [
           {
             label: 'Flight Match',
@@ -179,7 +175,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
       {
         label: 'Legacy Website',
         icon: 'pi pi-history',
-        visible: true,
+        visible: this.currentUser?.is_admin || !this.maintenance,
         url: 'http://aplgolfleague.com/cgi-bin/golf_cgi/aplgolf.pl',
       },
       {

--- a/src/app/maintenance/maintenance.component.html
+++ b/src/app/maintenance/maintenance.component.html
@@ -7,5 +7,5 @@
     width="200px"
   />
   <p class="font-bold text-2xl">APL Golf League</p>
-  <p class="font-semibold py-5">Website is under maintenance. Check back again soon!</p>
+  <p class="font-semibold py-5">The website is under maintenance. Check back again soon!</p>
 </div>

--- a/src/app/maintenance/maintenance.guard.ts
+++ b/src/app/maintenance/maintenance.guard.ts
@@ -12,7 +12,11 @@ export class MaintenanceGuard implements CanActivateChild {
   private authService = inject(AuthService);
   private router = inject(Router);
 
-  canActivateChild(): boolean | UrlTree | Observable<boolean | UrlTree> | Promise<boolean | UrlTree> {
+  canActivateChild():
+    | boolean
+    | UrlTree
+    | Observable<boolean | UrlTree>
+    | Promise<boolean | UrlTree> {
     return this.authService.user.pipe(
       take(1),
       map((user) => {

--- a/src/app/maintenance/maintenance.guard.ts
+++ b/src/app/maintenance/maintenance.guard.ts
@@ -1,0 +1,26 @@
+import { inject, Injectable } from '@angular/core';
+import { CanActivateChild, Router, UrlTree } from '@angular/router';
+import { map, Observable, take } from 'rxjs';
+
+import { AuthService } from 'src/app/auth/auth.service';
+import { environment } from 'src/environments/environment';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class MaintenanceGuard implements CanActivateChild {
+  private authService = inject(AuthService);
+  private router = inject(Router);
+
+  canActivateChild(): boolean | UrlTree | Observable<boolean | UrlTree> | Promise<boolean | UrlTree> {
+    return this.authService.user.pipe(
+      take(1),
+      map((user) => {
+        if (!environment.maintenance || (user != null && user.is_admin)) {
+          return true;
+        }
+        return this.router.createUrlTree(['/maintenance']);
+      }),
+    );
+  }
+}

--- a/src/environments/environment.staging.ts
+++ b/src/environments/environment.staging.ts
@@ -3,5 +3,5 @@ export const environment = {
   apiUrl: 'https://aplgolfapi.staging.jaunzenet.com/',
   title: 'APL Golf League - STAGING',
   version: 'STAGING',
-  maintenance: true,
+  maintenance: false,
 };

--- a/src/environments/environment.staging.ts
+++ b/src/environments/environment.staging.ts
@@ -3,5 +3,5 @@ export const environment = {
   apiUrl: 'https://aplgolfapi.staging.jaunzenet.com/',
   title: 'APL Golf League - STAGING',
   version: 'STAGING',
-  maintenance: false,
+  maintenance: true,
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -4,10 +4,10 @@
 
 export const environment = {
   production: false,
-  apiUrl: 'https://localhost/',
+  apiUrl: 'https://aplgolfapi.staging.jaunzenet.com/',
   title: 'APL Golf League - DEVELOPMENT',
   version: 'DEVELOPMENT',
-  maintenance: false,
+  maintenance: true,
 };
 
 /*


### PR DESCRIPTION
This PR adds a maintenance guard that reroutes every route when in maintenance mode, unless the user is logged in as admin. The header and footer are adjusted as well to show information in that maintenance + admin condition.