### PR TITLE
Change team name limit maximum to 32 characters

### DIFF
--- a/src/app/teams/team-create/team-create.component.html
+++ b/src/app/teams/team-create/team-create.component.html
@@ -25,7 +25,7 @@
       placeholder="Ex: Teamy McTeamFace"
       required
       minlength="3"
-      maxlength="25"
+      maxlength="32"
       pattern="[a-zA-Z0-9\s\-']+"
     />
   </p-inputgroup>

--- a/src/app/teams/tournament-team-create/tournament-team-create.component.html
+++ b/src/app/teams/tournament-team-create/tournament-team-create.component.html
@@ -25,7 +25,7 @@
       placeholder="Ex: Teamy McTeamFace"
       required
       minlength="3"
-      maxlength="25"
+      maxlength="32"
       pattern="[a-zA-Z0-9\s\-']+"
     />
   </p-inputgroup>


### PR DESCRIPTION
This PR increases the team name limit to 32 character maximum, to match backend validation.