### PR TITLE
Fix capitalization of officer committee enums

### DIFF
--- a/src/app/officers/officers-dashboard/officers-dashboard.component.html
+++ b/src/app/officers/officers-dashboard/officers-dashboard.component.html
@@ -25,7 +25,7 @@
         <div class="flex flex-row items-center justify-between p-4">
           @for (item of items; track item) {
             <div class="col-span-2 listItem">
-              @if (item.committee === 'LEAGUE') {
+              @if (item.committee === 'League') {
                 <div class="flex flex-col sm:flex-row sm:items-center p-2 gap-4">
                   <div
                     class="flex flex-col md:flex-row justify-between md:items-center flex-1 gap-6 ml-4"

--- a/src/app/shared/officer.model.ts
+++ b/src/app/shared/officer.model.ts
@@ -1,11 +1,11 @@
 export enum Committee {
-  LEAGUE = 'LEAGUE',
-  EXECUTIVE = 'EXECUTIVE',
-  RULES = 'RULES',
-  TOURNAMENT = 'TOURNAMENT',
-  BANQUET_AND_AWARDS = 'BANQUET_AND_AWARDS',
-  PUBLICITY = 'PUBLICITY',
-  PLANNING = 'PLANNING',
+  LEAGUE = 'League',
+  EXECUTIVE = 'Executive',
+  RULES = 'Rules',
+  TOURNAMENT = 'Tournament',
+  BANQUET_AND_AWARDS = 'Banquet And Awards',
+  PUBLICITY = 'Publicity',
+  PLANNING = 'Planning',
 }
 
 export interface Officer {


### PR DESCRIPTION
This PR fixes capitalization for officer committee enums, previously the frontend assume all caps like backend but now they return in display-friendly format.