### PR TITLE
Coerce team golfer role to title case

### DIFF
--- a/src/app/flights/team-home/team-info/team-info.component.ts
+++ b/src/app/flights/team-home/team-info/team-info.component.ts
@@ -18,12 +18,12 @@ export class TeamInfoComponent {
   @Input() teamStandings: FlightStandingsTeam | undefined;
 
   getCaptainName(): string | undefined {
-    const captain = this.teamData.golfers.filter((golfer) => golfer.role === 'Captain')[0];
-    return captain.golfer_name;
+    const captain = this.teamData?.golfers?.find((golfer) => golfer.role === 'Captain');
+    return captain?.golfer_name;
   }
 
   getCaptainEmail(): string | undefined {
-    const captain = this.teamData.golfers.filter((golfer) => golfer.role === 'Captain')[0];
-    return captain.golfer_email;
+    const captain = this.teamData?.golfers?.find((golfer) => golfer.role === 'Captain');
+    return captain?.golfer_email;
   }
 }

--- a/src/app/teams/teams.service.ts
+++ b/src/app/teams/teams.service.ts
@@ -82,6 +82,14 @@ export class TeamsService {
     this.http
       .get<FlightTeamDataWithMatches>(environment.apiUrl + `teams/${id}`)
       .subscribe((result) => {
+        if (result.golfers) {
+          result.golfers = result.golfers.map((golfer) => ({
+            ...golfer,
+            role: golfer.role
+              ? golfer.role.charAt(0).toUpperCase() + golfer.role.slice(1).toLowerCase()
+              : golfer.role,
+          }));
+        }
         this.teamData = result;
         this.teamDataUpdated.next(result);
       });


### PR DESCRIPTION
This PR fixes errors in the team home component caused by role being all-caps and not titlecase for a specific API return. Need to diagnose the backend difference too, but this is at least compatible with both.