### PR TITLE
Fix handicap strokes bug for tournaments with multi best ball

### DIFF
--- a/src/app/tournaments/tournament-home/tournament-scorecard/tournament-scorecard.component.ts
+++ b/src/app/tournaments/tournament-home/tournament-scorecard/tournament-scorecard.component.ts
@@ -192,7 +192,6 @@ export class TournamentScorecardComponent implements OnInit, OnChanges {
     const holeResultData: HoleResultData[] = [];
     for (let holeIdx = 0; holeIdx < rounds[0].holes.length; holeIdx++) {
       const hole = rounds[0].holes[holeIdx];
-
       let holePar = hole.par;
       let grossScore = 99;
       let netScore = 99;
@@ -202,7 +201,7 @@ export class TournamentScorecardComponent implements OnInit, OnChanges {
         const netScores = [99, 99];
         for (const round of rounds) {
           const handicapStrokes = this.computeHandicapStrokes(
-            hole.stroke_index,
+            round.holes[holeIdx].stroke_index,
             round.golfer_playing_handicap,
           );
           if (round.holes[holeIdx].gross_score < grossScores[1]) {

--- a/src/app/tournaments/tournament-scorecard-create/tournament-scorecard-create.component.ts
+++ b/src/app/tournaments/tournament-scorecard-create/tournament-scorecard-create.component.ts
@@ -546,8 +546,8 @@ export class TournamentScorecardCreateComponent implements OnInit, OnDestroy {
     for (let holeIdx = 0; holeIdx < rounds[0].holes.length; holeIdx++) {
       const hole = rounds[0].holes[holeIdx];
       let holePar = hole.par;
-      let grossScore = 0;
-      let netScore = 0;
+      let grossScore = 99;
+      let netScore = 99;
       if (this.selectedTournamentData?.bestball === 2) {
         holePar = hole.par * 2;
         const grossScores = rounds


### PR DESCRIPTION
This PR fixes a bug where the handicap strokes could be calculated using the wrong stroke index for a golfer whose tees differ from the "first" golfer in the team's group of rounds. It was a zero-sum error (would be corrected the other way elsewhere) but a confusing and incorrect display.